### PR TITLE
Adding paragraph completion (#73)

### DIFF
--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/Completions.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/Completions.java
@@ -41,10 +41,12 @@ public class Completions {
    */
   private AbstractCompletion initializeCompletionsChain() {
     AbstractCompletion variableProvider = new VariableCompletion();
+    AbstractCompletion paragraphProvider = new ParagraphCompletion();
     AbstractCompletion snippetProvider = new SnippetCompletion();
     AbstractCompletion keywordProvider = new KeywordCompletion();
 
-    variableProvider.setNextCompletionProvider(snippetProvider);
+    variableProvider.setNextCompletionProvider(paragraphProvider);
+    paragraphProvider.setNextCompletionProvider(snippetProvider);
     snippetProvider.setNextCompletionProvider(keywordProvider);
 
     return variableProvider;

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/KeywordCompletion.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/KeywordCompletion.java
@@ -33,7 +33,7 @@ class KeywordCompletion extends AbstractCompletion {
 
   @Override
   protected String getSortOrderPrefix() {
-    return "2"; // Keywords should go after the variables in the completions list
+    return "3"; // Keywords should go after Paragraphs in the completions list
   }
 
   @Override

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/ParagraphCompletion.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/ParagraphCompletion.java
@@ -14,42 +14,35 @@
 package com.ca.lsp.cobol.service.delegates.completions;
 
 import com.ca.lsp.cobol.service.MyDocumentModel;
-import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.CompletionItemKind;
-import org.eclipse.lsp4j.InsertTextFormat;
-
+import com.ca.lsp.cobol.service.delegates.validations.AnalysisResult;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
+import org.eclipse.lsp4j.CompletionItemKind;
 
-public class SnippetCompletion extends AbstractCompletion {
-  private static final Snippets SNIPPETS = new Snippets();
+public class ParagraphCompletion extends AbstractCompletion {
 
   @Override
   Collection<String> getCompletionSource(MyDocumentModel document) {
-    return SNIPPETS.getLabels();
+    return Optional.ofNullable(document)
+        .map(MyDocumentModel::getAnalysisResult)
+        .map(AnalysisResult::getParagraphs)
+        .orElse(Collections.emptySet());
   }
 
   @Override
   String tryResolve(String label) {
-    return Optional.ofNullable(SNIPPETS.getInformationFor(label))
-        .map(string -> string.replaceAll("[${\\d:}]", ""))
-        .orElse(null);
+    // Cannot resolve description for this type of completion 
+    return null;
   }
 
   @Override
   protected String getSortOrderPrefix() {
-    return "2";
-  }
-
-  @Override
-  protected CompletionItem customize(CompletionItem item) {
-    item.setInsertText(SNIPPETS.getInformationFor(item.getLabel()));
-    item.setInsertTextFormat(InsertTextFormat.Snippet);
-    return item;
+    return "1"; // paragraphs are supposed to be the second in the completions list
   }
 
   @Override
   protected CompletionItemKind getKind() {
-    return CompletionItemKind.Snippet;
+    return CompletionItemKind.Method;
   }
 }

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/VariableCompletion.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/main/java/com/ca/lsp/cobol/service/delegates/completions/VariableCompletion.java
@@ -34,7 +34,7 @@ class VariableCompletion extends AbstractCompletion {
 
   @Override
   String tryResolve(String label) {
-    // Not yet supported
+    // Cannot resolve description for this type of completion
     return null;
   }
 

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/AllTests.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/AllTests.java
@@ -22,6 +22,7 @@ import com.ca.lsp.cobol.service.delegates.HighlightsTest;
 import com.ca.lsp.cobol.service.delegates.LanguageEnginesTest;
 import com.ca.lsp.cobol.service.delegates.ValidationTest;
 import com.ca.lsp.cobol.service.delegates.completions.CompletionsChainTest;
+import com.ca.lsp.cobol.service.delegates.completions.ParagraphCompletionTest;
 import com.ca.lsp.cobol.service.delegates.completions.SnippetCompletionTest;
 import com.ca.lsp.cobol.service.delegates.completions.VariableCompletionTest;
 import com.ca.lsp.cobol.service.delegates.references.ReferencesTest;
@@ -50,6 +51,7 @@ import org.junit.runners.Suite.SuiteClasses;
   VariableCompletionTest.class,
   CompletionsChainTest.class,
   SnippetCompletionTest.class,
+  ParagraphCompletionTest.class,
   ReferencesTest.class,
   DefinitionsAndUsagesTest.class,
   TestResponsesNotContainLineBreaks.class,

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/completions/ParagraphCompletionTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/completions/ParagraphCompletionTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019 Broadcom.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Broadcom, Inc. - initial API and implementation
+ */
+package com.ca.lsp.cobol.service.delegates.completions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.ca.lsp.cobol.service.MyDocumentModel;
+import com.ca.lsp.cobol.service.delegates.validations.AnalysisResult;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.Test;
+
+/** Test to check ParagraphCompletion */
+public class ParagraphCompletionTest {
+  private static final String TEXT =
+      "       Identification Division. \n"
+          + "       Program-id.    ProgramId.\n"
+          + "       Data Division.\n"
+          + "       Working-Storage Section.\n"
+          + "       01   outer1.\n"
+          + "        02   INNER1      PIC 9(4) Binary. \n"
+          + "        02   inner2      PIC X(10).\n"
+          + "       Procedure Division.\n"
+          + "       000-Main-Logic.\n"
+          + "           Perform 100-Test.\n"
+          + "           Stop Run.\n"
+          + "       100-Test.\n"
+          + "           Move INNER1 of OUTER1 to Str.\n"
+          + "       End program ProgramId.";
+
+  /**
+   * this test creates a test document, scans it for paragraph names, adds them to completionItems,
+   * then attempts to find the expected output
+   */
+  @Test
+  public void testParagraphCompletion() {
+    ParagraphCompletion completion = new ParagraphCompletion();
+    MyDocumentModel document = createModel();
+
+    List<CompletionItem> completionItems =
+        completion.collectCompletions(document, createCompletionParams());
+
+    assertEquals(2, completionItems.size());
+    assertTrue(
+        "100-Test",
+        completionItems.get(0).getLabel().contains("100-Test")
+            || completionItems.get(0).getLabel().contains("000-Main-Logic"));
+    assertTrue(
+        "000-Main-Logic",
+        completionItems.get(1).getLabel().contains("100-Test")
+            || completionItems.get(1).getLabel().contains("000-Main-Logic"));
+  }
+
+  private CompletionParams createCompletionParams() {
+    return new CompletionParams(new TextDocumentIdentifier("id"), new Position(8, 0));
+  }
+
+  private MyDocumentModel createModel() {
+    Map<String, List<Range>> paragraphDefinitions = new HashMap<>();
+    paragraphDefinitions.put(
+        "000-Main-Logic",
+        Collections.singletonList(new Range(new Position(7, 6), new Position(7, 20))));
+    paragraphDefinitions.put(
+        "100-Test",
+        Collections.singletonList(new Range(new Position(10, 6), new Position(10, 14))));
+
+    AnalysisResult result =
+        new AnalysisResult(
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            paragraphDefinitions,
+            Collections.emptyMap());
+
+    return new MyDocumentModel(TEXT, result);
+  }
+}

--- a/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/completions/SnippetCompletionTest.java
+++ b/com.ca.lsp.cobol/lsp-service-cobol/src/test/java/com/ca/lsp/cobol/service/delegates/completions/SnippetCompletionTest.java
@@ -58,7 +58,7 @@ public class SnippetCompletionTest {
 
   @Test
   public void testGetSortOrderPrefix() {
-    assertEquals("1", provider.getSortOrderPrefix());
+    assertEquals("2", provider.getSortOrderPrefix());
   }
 
   @Test


### PR DESCRIPTION
* adding paragraph completion

Signed-off-by: Ramy Abdalla <ramy.abdalla@broadcom.com>

* adding unit tests for paragraph completion

Signed-off-by: Ramy Abdalla <ramy.abdalla@broadcom.com>

* removing commented code

Signed-off-by: Ramy Abdalla <ramy.abdalla@broadcom.com>

* updated comment

Signed-off-by: Ramy Abdalla <ramy.abdalla@broadcom.com>

* throwing UnsupportedOperationException instead of null

Signed-off-by: Ramy Abdalla <ramy.abdalla@broadcom.com>

* adding description for test file

Signed-off-by: Ramy Abdalla <ramy.abdalla@broadcom.com>

* reverting to return null, and adding better comments

Signed-off-by: Ramy Abdalla <ramy.abdalla@broadcom.com>